### PR TITLE
Add the missing market_segment to the accepted_values test

### DIFF
--- a/models/marts/fct_orders.sql
+++ b/models/marts/fct_orders.sql
@@ -1,12 +1,16 @@
-SELECT
-  orders_hub.O_ORDERKEY,
-  COUNT(nl.L_QUANTITY) as part_count,
-  SUM(nl.L_DISCOUNT) as total_discount,
-  SUM(nl.L_TAX) as total_tax,
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select
+  orders_hub.O_ORDERKEY as order_key,
+  count(nl.L_QUANTITY) as part_count,
+  sum(nl.L_DISCOUNT) as total_discount,
+  sum(nl.L_TAX) as total_tax,
   sum(nl.L_EXTENDEDPRICE) as price
-FROM {{ ref('LINEITEM_NL') }} as nl
-LEFT JOIN {{ ref('ORDERS_H') }} as orders_hub
-  ON nl.hk_order_h = orders_hub.hk_order_h
-LEFT JOIN {{ ref('ORDERS_N_S') }} as orders_sat
-  ON orders_hub.HK_ORDER_H = orders_sat.HK_ORDER_H
+from {{ ref('LINEITEM_NL') }} as nl
+left join {{ ref('ORDERS_H') }} as orders_hub on nl.HK_ORDER_H = orders_hub.hk_order_h
+left join {{ ref('ORDERS_N_S') }} as orders_sat on orders_hub.HK_ORDER_H = orders_sat.HK_ORDER_H
 group by 1

--- a/models/marts/models.yml
+++ b/models/marts/models.yml
@@ -25,7 +25,6 @@ models:
           - accepted_values:
               values:
                 - "(unknown)"  # This is from the DV Ghost Record
-                - "AUTOMOBILE"
                 - "BUILDING"
                 - "FURNITURE"
                 - "HOUSEHOLD"

--- a/models/marts/models.yml
+++ b/models/marts/models.yml
@@ -30,7 +30,6 @@ models:
                 - "FURNITURE"
                 - "HOUSEHOLD"
                 - "MACHINERY"
-                - "AUTOMOBILE"
 
   - name: fct_orders
     description: >

--- a/models/marts/models.yml
+++ b/models/marts/models.yml
@@ -7,7 +7,7 @@ models:
       most important attributes used in common analyses across the organization.
     columns:
       - name: customer_key
-        description: Customer primary key, as known from source system.
+        description: Customer primary key, as known from source system
         tests:
           - unique
           - not_null
@@ -29,4 +29,21 @@ models:
                 - "FURNITURE"
                 - "HOUSEHOLD"
                 - "MACHINERY"
-      
+
+  - name: fct_orders
+    description: >
+      A fact model of all the orders in our databases.
+    columns:
+      - name: order_key
+        description: Order primary key, as known from source system
+        tests:
+          - unique
+          - not_null
+      - name: part_count
+        description: The number of parts associated with the order
+      - name: total_discount
+        description: Total amount of discounts applied to the order
+      - name: total_tax
+        description: Total amount of tax applied to the order
+      - name: price
+        description: Total price of the order

--- a/models/marts/models.yml
+++ b/models/marts/models.yml
@@ -30,6 +30,7 @@ models:
                 - "FURNITURE"
                 - "HOUSEHOLD"
                 - "MACHINERY"
+                - "AUTOMOBILE"
 
   - name: fct_orders
     description: >

--- a/models/marts/models.yml
+++ b/models/marts/models.yml
@@ -19,6 +19,7 @@ models:
         description: Primary phone number provided for handling general inquiries
       - name: account_balance
         description: Latest account balance recorded in our systems
+
       - name: market_segment
         description: The area of industry the customer operates within
         tests:
@@ -29,6 +30,7 @@ models:
                 - "FURNITURE"
                 - "HOUSEHOLD"
                 - "MACHINERY"
+                - "AUTOMOBILE"
 
   - name: fct_orders
     description: >

--- a/models/marts/models.yml
+++ b/models/marts/models.yml
@@ -25,6 +25,7 @@ models:
           - accepted_values:
               values:
                 - "(unknown)"  # This is from the DV Ghost Record
+                - "AUTOMOBILE"
                 - "BUILDING"
                 - "FURNITURE"
                 - "HOUSEHOLD"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: ScalefreeCOM/datavault4dbt
     version: 1.2.1
+  - package: calogica/dbt_expectations
+    version: 0.10.3


### PR DESCRIPTION
## Description & motivation

I've discovered a missing value, `MACHINERY`, from the `market_segment` column. Since this is a `market_segment` we have customers in, it is appropriate to add this value as an accepted value in the customers attribute.


## Checklist:
<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] My SQL follows the [dbt Labs style guide](https://github.com/fishtown-analytics/corp/blob/master/dbt_coding_conventions.md).
- [ ] I have materialized my models appropriately.
- [ ] I have added appropriate tests and documentation to any new models.
- [ ] I have updated the README file.